### PR TITLE
0.2.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Release 0.2.1 (minor)
+- Ensure that the modal file picker works under heavy load conditions with flexible delay to promote core file picker
+  above the modal glasspane.
+
 ## Release 0.2.0 (major)
 - Various sub-path refactoring.
 - Overall refinement / streamlining.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typhonjs-fvtt/standard",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Provides a standard Svelte component library for the TyphonJS Runtime Library and Foundry VTT.",
   "type": "module",
   "author": "Michael Leahy <support@typhonjs.io> (https://github.com/typhonrt)",


### PR DESCRIPTION
## Release 0.2.1 (minor)
- Ensure that the modal file picker works under heavy load conditions with flexible delay to promote core file picker
  above the modal glasspane.